### PR TITLE
local storage fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -307,6 +307,13 @@ function cleanCompleted() {
 
 //function that delete an element
 function deleteElement(elem) {
+  let list = document.querySelector("#ViewSection");
+  let listItems = list.querySelectorAll("div");
+  for (let i = 0; i < listItems.length; i++) {
+    let task = listItems[i].querySelector("span");
+    task.innerHTML = task.innerText;
+  }
+  document.getElementById("searchInput").value=""
   elem.closest("section").id === "ViewSection"
     ? delFromView(elem)
     : removeFromLocalStorage("completedTasks", elem);


### PR DESCRIPTION
the problem was that you saved all of the tasks' HTML as a single string, and to remove a task you used "replace(task's HTML)"; But, when using the search mechanism the inner html of the tasks is being changed, adding a span to decorate selected text. Because of that the tasks inner HTML at that moment is different then the one that was saved.

THE SOLUTION: clearing the tasks' HTML from any spans, the same way you clear it when the search bar is empty.

**side-note: I thought it will make sense that the search bar will become empty as a result of delrting a task, so it get cleared now when you do.